### PR TITLE
feat: Introduce GitHub Actions for ory-dev

### DIFF
--- a/.github/workflows/ory-dev.yml
+++ b/.github/workflows/ory-dev.yml
@@ -1,0 +1,37 @@
+name: ory-dev
+
+on: [push]
+
+defaults:
+  run:
+    working-directory: tools/ory-dev
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [1.14.x]
+    steps:
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+        id: go
+
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - run: go mod download
+      - run: go mod verify
+      - run: go build -v .
+      # TODO: comment in after fix swagger_sanitize_test.go
+      #- run: go test -v ./...

--- a/.github/workflows/ory-dev.yml
+++ b/.github/workflows/ory-dev.yml
@@ -7,6 +7,12 @@ defaults:
     working-directory: tools/ory-dev
 
 jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    container: golangci/golangci-lint:v1.27.0-alpine
+    steps:
+      - uses: actions/checkout@v2
+      - run: golangci-lint run
 
   build:
     name: Build

--- a/tools/ory-dev/cmd/fizz_migrations_tests_sync.go
+++ b/tools/ory-dev/cmd/fizz_migrations_tests_sync.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var fizzTestRegex = regexp.MustCompile("([0-9]+)_([a-zA-Z_0-9]+)(\\.(mysql|postgres|cockroach|sqlite)|)\\.up\\.(fizz|sql)")
+var fizzTestRegex = regexp.MustCompile(`([0-9]+)_([a-zA-Z_0-9]+)(\.(mysql|postgres|cockroach|sqlite)|)\.up\.(fizz|sql)`)
 
 func makeFileIfNotExist(p string) error {
 	if _, err := os.Stat(p); !os.IsNotExist(err) {


### PR DESCRIPTION
Introduce GitHub Actions for ory-dev to prevent accident such as #14.

* build check
* lint check by golangci

But I couldn't add test because `swagger_sanitize_test.go` is failed.