### PR TITLE
docs: add CLA to PR template

### DIFF
--- a/templates/repository/library/.github/pull_request_template.md
+++ b/templates/repository/library/.github/pull_request_template.md
@@ -24,15 +24,15 @@ Put an `x` in the boxes that apply. You can also fill these out after creating t
 them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
 -->
 
-- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
-- [ ] I have read the [security policy](../security/policy)
+- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
+- [ ] I have read the [security policy](../security/policy).
 - [ ] I confirm that this pull request does not address a security
       vulnerability. If this pull request addresses a security vulnerability, I
       confirm that I got green light (please contact
       [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
       the changes.
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] I have added necessary documentation within the code base (if appropriate)
+- [ ] I have added tests that prove my fix is effective or that my feature works.
+- [ ] I have added necessary documentation within the code base (if appropriate).
 
 ## Further comments
 


### PR DESCRIPTION
https://github.com/ory/meta/issues/32
Is it unnecessary here, since the CLA-Bot notifies you anyway if you have not signed it? 
But at least its mentioned I guess...