### PR TITLE
fix: match newline after adopters and ecosystem

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -49,8 +49,8 @@ EOF
         sed '/Contributing to/d' "$workdir/docs/docs/contributing.md"
     fi
 
-    perl -0pe 's#<!--\s*BEGIN ADOPTERS\s*-->.*<!--\s*END ADOPTERS\s*-->#`cat templates/repository/common/ADOPTERS.md`#gse' -i "$workdir/README.md"
-    perl -0pe 's#<!--\s*BEGIN ECOSYSTEM\s*-->.*<!--\s*END ECOSYSTEM\s*-->#`cat templates/repository/common/PROJECTS.md`#gse' -i "$workdir/README.md"
+    perl -0pe 's#<!--\s*BEGIN ADOPTERS\s*-->.*<!--\s*END ADOPTERS\s*-->\n#`cat templates/repository/common/ADOPTERS.md`#gse' -i "$workdir/README.md"
+    perl -0pe 's#<!--\s*BEGIN ECOSYSTEM\s*-->.*<!--\s*END ECOSYSTEM\s*-->\n#`cat templates/repository/common/PROJECTS.md`#gse' -i "$workdir/README.md"
 
     (cd "$workdir"; \
       git add -A; \


### PR DESCRIPTION
Currently there is always a newline added to the adopters and ecosystem sections whenever sync runs.
Closes https://github.com/ory/kratos/pull/724
Closes https://github.com/ory/hydra/pull/2083