### PR TITLE
fix: move prettier to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,14 @@
     "ory-prettier-styles": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ory-prettier-styles/-/ory-prettier-styles-1.0.1.tgz",
-      "integrity": "sha512-YIJMrd5K2LzxoC01n3sNgsNa1u4IRBdWpE5bTlKqFy+kTtQy8pCv0JKw8wXwpdHfkOIeXt4wcVM3zYGRlmPGbQ=="
+      "integrity": "sha512-YIJMrd5K2LzxoC01n3sNgsNa1u4IRBdWpE5bTlKqFy+kTtQy8pCv0JKw8wXwpdHfkOIeXt4wcVM3zYGRlmPGbQ==",
+      "dev": true
     },
     "prettier": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
-      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg=="
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/ory/meta.git"
   },
-  "dependencies": {
+  "devDependencies": {
     "ory-prettier-styles": "^1.0.1",
     "prettier": "^2.1.2"
   }


### PR DESCRIPTION
The CI script installing prettier uses jq to get the prettier version and expects it to be under `devDependencies`