### PR TITLE
docs: contributing link fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,6 @@ https://github.com/ory/meta/blob/master/templates/repository/CONTRIBUTING.md
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [Contributing to ORY {{Project}}](#contributing-to-ory-project)
   - [Introduction](#introduction)
   - [FAQ](#faq)
   - [How can I contribute?](#how-can-i-contribute)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ do this is via the [ORY Community](https://community.ory.sh/) or join the
 ## How can I contribute?
 
 If you want to start contributing code right away, we have a
-[list of good first issues](https://github.com/ory/{{Project}}/labels/good%20first%20issue).
+[list of good first issues](https://github.com/ory/{{Project}/labels/good%20first%20issue).
 
 There are many other ways you can contribute without writing any code. Here are
 a few things you can do to help out:
@@ -161,7 +161,7 @@ Please provide documentation when changing, removing, or adding features.
 Documentation resides in the project's docs folder. Generate API and
 configuration reference documentation using `cd docs; npm run gen`.
 
-For further instructions please head over to [docs/README.md](docs/README.md).
+For further instructions please head over to [docs/README.md](ttps://github.com/ory/{{Project}}/blob/master/README.md).
 
 ## Disclosing vulnerabilities
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for contributing changes to this document! Because we use a central re
 to synchronize this file across all our repositories, make sure to make your edits
 in the correct file, which you can find here:
 
-https://github.com/ory/meta/blob/master/templates/repository/CONTRIBUTING.md
+https://github.com/ory/meta/blob/master/CONTRIBUTING.md
 
 -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,17 +13,18 @@ https://github.com/ory/meta/blob/master/templates/repository/CONTRIBUTING.md
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [Introduction](#introduction)
-- [FAQ](#faq)
-- [How can I contribute?](#how-can-i-contribute)
-- [Communication](#communication)
-- [Contributing Code](#contributing-code)
-- [Documentation](#documentation)
-- [Disclosing vulnerabilities](#disclosing-vulnerabilities)
-- [Code Style](#code-style)
-- [Pull request procedure](#pull-request-procedure)
-- [Working with Forks](#working-with-forks)
-- [Conduct](#conduct)
+- [Contributing to ORY {{Project}}](#contributing-to-ory-project)
+  - [Introduction](#introduction)
+  - [FAQ](#faq)
+  - [How can I contribute?](#how-can-i-contribute)
+  - [Communication](#communication)
+  - [Contributing Code](#contributing-code)
+  - [Documentation](#documentation)
+  - [Disclosing vulnerabilities](#disclosing-vulnerabilities)
+  - [Code Style](#code-style)
+  - [Pull request procedure](#pull-request-procedure)
+    - [Working with Forks](#working-with-forks)
+  - [Conduct](#conduct)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -55,7 +56,7 @@ do this is via the [ORY Community](https://community.ory.sh/) or join the
 ## FAQ
 
 - I am new to the community. Where can I find the
-  [ORY Community Code of Conduct?](CODE_OF_CONDUCT.md)
+  [ORY Community Code of Conduct?](https://github.com/ory/meta/blob/master/CODE_OF_CONDUCT.md)
 
 - I have a question. Where can I get
   [answers to questions regarding ORY {{Project}}?](#communication)
@@ -157,7 +158,7 @@ should be merged by the submitter after review.
 ## Documentation
 
 Please provide documentation when changing, removing, or adding features.
-Documentation resides in the project's [docs](docs) folder. Generate API and
+Documentation resides in the project's docs folder. Generate API and
 configuration reference documentation using `cd docs; npm run gen`.
 
 For further instructions please head over to [docs/README.md](docs/README.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,17 +13,17 @@ https://github.com/ory/meta/blob/master/templates/repository/CONTRIBUTING.md
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-  - [Introduction](#introduction)
-  - [FAQ](#faq)
-  - [How can I contribute?](#how-can-i-contribute)
-  - [Communication](#communication)
-  - [Contributing Code](#contributing-code)
-  - [Documentation](#documentation)
-  - [Disclosing vulnerabilities](#disclosing-vulnerabilities)
-  - [Code Style](#code-style)
-  - [Pull request procedure](#pull-request-procedure)
-    - [Working with Forks](#working-with-forks)
-  - [Conduct](#conduct)
+- [Introduction](#introduction)
+- [FAQ](#faq)
+- [How can I contribute?](#how-can-i-contribute)
+- [Communication](#communication)
+- [Contributing Code](#contributing-code)
+- [Documentation](#documentation)
+- [Disclosing vulnerabilities](#disclosing-vulnerabilities)
+- [Code Style](#code-style)
+- [Pull request procedure](#pull-request-procedure)
+  - [Working with Forks](#working-with-forks)
+- [Conduct](#conduct)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,18 +13,17 @@ https://github.com/ory/meta/blob/master/templates/repository/CONTRIBUTING.md
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [Contributing to ORY {{Project}}](#contributing-to-ory-project)
-  - [Introduction](#introduction)
-  - [FAQ](#faq)
-  - [How can I contribute?](#how-can-i-contribute)
-  - [Communication](#communication)
-  - [Contributing Code](#contributing-code)
-  - [Documentation](#documentation)
-  - [Disclosing vulnerabilities](#disclosing-vulnerabilities)
-  - [Code Style](#code-style)
-  - [Pull request procedure](#pull-request-procedure)
-    - [Working with Forks](#working-with-forks)
-  - [Conduct](#conduct)
+- [Introduction](#introduction)
+- [FAQ](#faq)
+- [How can I contribute?](#how-can-i-contribute)
+- [Communication](#communication)
+- [Contributing Code](#contributing-code)
+- [Documentation](#documentation)
+- [Disclosing vulnerabilities](#disclosing-vulnerabilities)
+- [Code Style](#code-style)
+- [Pull request procedure](#pull-request-procedure)
+  - [Working with Forks](#working-with-forks)
+- [Conduct](#conduct)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -158,11 +157,12 @@ should be merged by the submitter after review.
 ## Documentation
 
 Please provide documentation when changing, removing, or adding features.
-Documentation resides in the project's docs folder. Generate API and
-configuration reference documentation using `cd docs; npm run gen`.
+Documentation resides in the project's
+[docs](https://github.com/ory/{{Project}}/tree/master/docs) folder. Generate API
+and configuration reference documentation using `cd docs; npm run gen`.
 
 For further instructions please head over to
-[docs/README.md](ttps://github.com/ory/{{Project}}/blob/master/README.md).
+[docs/README.md](https://github.com/ory/{{Project}}/blob/master/README.md).
 
 ## Disclosing vulnerabilities
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,8 @@ Please provide documentation when changing, removing, or adding features.
 Documentation resides in the project's docs folder. Generate API and
 configuration reference documentation using `cd docs; npm run gen`.
 
-For further instructions please head over to [docs/README.md](ttps://github.com/ory/{{Project}}/blob/master/README.md).
+For further instructions please head over to
+[docs/README.md](ttps://github.com/ory/{{Project}}/blob/master/README.md).
 
 ## Disclosing vulnerabilities
 


### PR DESCRIPTION
There is still an error in
Line 163 the link to /docs/README.md
is broken (which I put in there btw.)

I tried to use (../../README.md) to make it work, but it does not and I dont know why.