### PR TITLE
docs: change to gh discussions

### DIFF
--- a/scripts/update-repository-templates.sh
+++ b/scripts/update-repository-templates.sh
@@ -34,7 +34,7 @@ function update {
     cp -R "templates/repository/$type/.github/" "$workdir/.github/"
 
     # Replace placeholders
-    sed -i '' -e "s|{{Project}}|$humanName|g" `find "$workdir/.github" -type f -print` "$workdir/CONTRIBUTING.md" "$workdir/SECURITY.md"
+    sed -i '' -e "s|{{Project}}|$humanName|g" `find "$workdir/.github" -type f -print` "$workdir/CONTRIBUTING.md" "$workdir/SECURITY.md" "/.github/ISSUE_TEMPLATE/config.yml"
 
     perl -0pe 's#<!--\s*BEGIN ADOPTERS\s*-->.*<!--\s*END ADOPTERS\s*-->#`cat templates/repository/common/ADOPTERS.md`#gse' -i "$workdir/README.md"
     perl -0pe 's#<!--\s*BEGIN ECOSYSTEM\s*-->.*<!--\s*END ECOSYSTEM\s*-->#`cat templates/repository/common/PROJECTS.md`#gse' -i "$workdir/README.md"

--- a/templates/repository/common/.github/ISSUE_TEMPLATE/config.yml
+++ b/templates/repository/common/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: ORY Community
-    url: https://community.ory.sh/
-    about: Please ask and answer questions here.
+    url: https://www.github.com/{{Project}}/discussions
+    about: Please ask and answer questions here, show your implementations and discuss ideas.
   - name: ORY Chat
     url: https://www.ory.sh/chat
     about: Hang out with other ORY community members and ask and answer questions.

--- a/templates/repository/common/CONTRIBUTING.md
+++ b/templates/repository/common/CONTRIBUTING.md
@@ -49,8 +49,9 @@ contributions, and don't want a wall of rules to get in the way of that.
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
 won't clash or be obviated by ORY {{Project}}'s normal direction. A great way to
-do this is via [ORY {{Project}} Discussions](https://github.com/ory/{{Project}}/discussions) or the
-[ORY Chat](https://www.ory.sh/chat).
+do this is via
+[ORY {{Project}} Discussions](https://github.com/ory/{{Project}}/discussions) or
+the [ORY Chat](https://www.ory.sh/chat).
 
 ## FAQ
 
@@ -110,8 +111,10 @@ a few things you can do to help out:
 We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
 questions, discuss bugs and feature requests, talk to other users of ORY, etc.
 
-Check out [ORY {{Project}} Discussions](https://github.com/ory/{{Project}}/discussions). This is a great place for in-depth
-discussions and lots of code examples, logs and similar data.
+Check out
+[ORY {{Project}} Discussions](https://github.com/ory/{{Project}}/discussions).
+This is a great place for in-depth discussions and lots of code examples, logs
+and similar data.
 
 You can also join our community hangout, if you want to speak to the ORY team
 directly or ask some questions. You can find more info on the hangouts in

--- a/templates/repository/common/CONTRIBUTING.md
+++ b/templates/repository/common/CONTRIBUTING.md
@@ -49,7 +49,7 @@ contributions, and don't want a wall of rules to get in the way of that.
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
 won't clash or be obviated by ORY {{Project}}'s normal direction. A great way to
-do this is via the [ORY Community](https://community.ory.sh/) or join the
+do this is via [ORY {{Project}} Discussions](https://github.com/ory/{{Project}}/discussions) or the
 [ORY Chat](https://www.ory.sh/chat).
 
 ## FAQ
@@ -110,7 +110,7 @@ a few things you can do to help out:
 We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
 questions, discuss bugs and feature requests, talk to other users of ORY, etc.
 
-We have a [forum](https://community.ory.sh/). This is a great place for in-depth
+Check out [ORY {{Project}} Discussions](https://github.com/ory/{{Project}}/discussions). This is a great place for in-depth
 discussions and lots of code examples, logs and similar data.
 
 You can also join our community hangout, if you want to speak to the ORY team

--- a/templates/repository/library/.github/pull_request_template.md
+++ b/templates/repository/library/.github/pull_request_template.md
@@ -7,7 +7,7 @@ with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`)
 If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
 chance substantial changes will be requested or that the changes will be rejected.
 
-You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
+You can discuss changes with maintainers either in the Github Discusssions in this repository or
 join the [ORY Chat](https://www.ory.sh/chat).
 -->
 

--- a/templates/repository/server/.github/pull_request_template.md
+++ b/templates/repository/server/.github/pull_request_template.md
@@ -7,7 +7,7 @@ with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`)
 If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
 chance substantial changes will be requested or that the changes will be rejected.
 
-You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
+You can discuss changes with maintainers either in the Github Discusssions in this repository or
 join the [ORY Chat](https://www.ory.sh/chat).
 -->
 


### PR DESCRIPTION
changed the scripts to provide the correct link to github discussions for each ory project.

should the replacement be added to synch.sh as well? (afaik sync.sh doesnt change the templates but to be consistent maybe). Let me know and I add it.