### PR TITLE
feat: add repo replace

### DIFF
--- a/scripts/update-repository-templates.sh
+++ b/scripts/update-repository-templates.sh
@@ -34,7 +34,8 @@ function update {
     cp -R "templates/repository/$type/.github/" "$workdir/.github/"
 
     # Replace placeholders
-    sed -i '' -e "s|{{Project}}|$humanName|g" `find "$workdir/.github" -type f -print` "$workdir/CONTRIBUTING.md" "$workdir/SECURITY.md" "/.github/ISSUE_TEMPLATE/config.yml"
+    sed -i '' -e "s|{{Project}}|$humanName|g" `find "$workdir/.github" -type f -print` "$workdir/CONTRIBUTING.md" "$workdir/SECURITY.md"
+    sed -i '' -e "s|{{Repo}}|$name|g" `find "$workdir/.github" -type f -print` "/.github/ISSUE_TEMPLATE/config.yml"
 
     perl -0pe 's#<!--\s*BEGIN ADOPTERS\s*-->.*<!--\s*END ADOPTERS\s*-->#`cat templates/repository/common/ADOPTERS.md`#gse' -i "$workdir/README.md"
     perl -0pe 's#<!--\s*BEGIN ECOSYSTEM\s*-->.*<!--\s*END ECOSYSTEM\s*-->#`cat templates/repository/common/PROJECTS.md`#gse' -i "$workdir/README.md"

--- a/templates/repository/common/.github/ISSUE_TEMPLATE/config.yml
+++ b/templates/repository/common/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
-  - name: ORY Community
-    url: https://www.github.com/{{Project}}/discussions
+  - name: ORY {{Project}} Forum
+    url: https://www.github.com/{{Repo}}/discussions
     about: Please ask and answer questions here, show your implementations and discuss ideas.
   - name: ORY Chat
     url: https://www.ory.sh/chat

--- a/templates/repository/common/.github/ISSUE_TEMPLATE/config.yml
+++ b/templates/repository/common/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,6 @@ contact_links:
   - name: ORY Chat
     url: https://www.ory.sh/chat
     about: Hang out with other ORY community members and ask and answer questions.
-  - name: ORY Enterprise Contact
-    url: https://www.ory.sh/contact
-    about: Jared will help you with your enterprise-related inquiries.
+  - name: ORY Support for Business
+    url: https://github.com/ory/open-source-support/blob/master/README.md
+    about: Buy professional support for ORY {{Project}} .


### PR DESCRIPTION
This aims to fix the broken link generated by the script:

https://github.com/ory/hydra/pull/2241/files#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2R4

Please note that the org is missing, the repository is uppercase (it should be lowercase), and github.com does not use `www`.