### PR TITLE
feat: update sync for meta discussion

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -134,6 +134,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
       - name: Synchronize ORY Works
-        run: ./scripts/sync-library.sh ory/oryworks master Works
+        run: ./scripts/sync-library.sh ory/works master Works
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -31,8 +31,12 @@ function sync {
     # Copy specific templates for servers or library
     cp -R "templates/repository/$type/.github" "$workdir/"
 
-    for f in $(find "$workdir/.github/ISSUE_TEMPLATE" "$workdir/.github/pull_request_template.md" "$workdir/CONTRIBUTING.md" "$workdir/SECURITY.md" "$workdir/CODE_OF_CONDUCT.md" "$workdir/LICENSE" -type f -print); do
-      env -i REPOSITORY="$project" PROJECT="$humanName" /bin/bash -c "envsubst < \"$f\" | sponge \"$f\""
+    for f in $(find "./.github/ISSUE_TEMPLATE" " ./.github/pull_request_template.md" "CONTRIBUTING.md" "SECURITY.md" "CODE_OF_CONDUCT.md" "LICENSE" -type f -print); do
+      if [[ "$REPOSITORY" = "hydra" || $REPOSITORY = "kratos" || $REPOSITORY = "oathkeeper" || $REPOSITORY = "keto" ]]; then
+        env -i REPOSITORY="$project" PROJECT="$humanName" /bin/bash -c "envsubst < \"$f\" | sponge \"$f\""
+      else 
+        env -i REPOSITORY="meta" PROJECT="$humanName" /bin/bash -c "envsubst < \"$f\" | sponge \"$f\""
+      fi
     done
 
     # Copy contributing guide to docs if docs exist


### PR DESCRIPTION
I added an if statement to determine if the repository is one of the main Ory repositories, currently: 
kratos, hydra, oathkeeper, keto.
If yes, the script proceeds to replace all $repository with the repository name.
If not, then the repository name gets substituted with "meta".

This should point all synced Ory repositories to meta/discussions.

I tested it in /web and /kratos locally and worked fine.

(Ps: also changed sync.yml to include ory/works in the synch action again)