### PR TITLE
fix: fix $workdir

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -43,7 +43,7 @@ function sync {
     # env clears environment and sets REPOSITORY and PROJECT as new env variables
     # /bin/bash -c execute commands in " " in the new environment 
     # envsubst: replace all env variables found ($f) with the ones specified 2 steps before, pipe to sponge and write to file
-    for f in $(find "./.github/ISSUE_TEMPLATE" " ./.github/pull_request_template.md" "CONTRIBUTING.md" "SECURITY.md" "CODE_OF_CONDUCT.md" "LICENSE" -type f -print); do
+    for f in $(find "$workdir/.github/ISSUE_TEMPLATE" "$workdir/.github/pull_request_template.md" "$workdir/CONTRIBUTING.md" "$workdir/SECURITY.md" "$workdir/CODE_OF_CONDUCT.md" "$workdir/LICENSE" -type f -print); do
         env -i REPOSITORY="$project" PROJECT="$humanName" /bin/bash -c "envsubst < \"$f\" | sponge \"$f\""
     done
 


### PR DESCRIPTION
I removed $workdir in [the last commit](https://github.com/ory/meta/commit/d3a2438027877f14e8433bb44431544b9b91d210#diff-1272bfef55f69c7d75b2a92057586cba93ba4ced6160199525e011eab54be9c2) by accident. 
Just noticed it and put it in again.