### PR TITLE
Remove LDAP reference

### DIFF
--- a/templates/repository/common/PROJECTS.md
+++ b/templates/repository/common/PROJECTS.md
@@ -26,7 +26,9 @@ deal with: Self-service Login and Registration, Multi-Factor Authentication
 ### ORY Hydra: OAuth2 & OpenID Connect Server
 
 [ORY Hydra](https://github.com/ory/hydra) is an OpenID Certified™ OAuth2 and
-OpenID Connect Provider easily to be integrated with your frontend.
+OpenID Connect Provider which easily connects to any existing identity system by
+writing a tiny "bridge" application. Gives absolute control over user interface
+and user experience flows.
 
 ### ORY Oathkeeper: Identity & Access Proxy
 

--- a/templates/repository/common/PROJECTS.md
+++ b/templates/repository/common/PROJECTS.md
@@ -26,8 +26,7 @@ deal with: Self-service Login and Registration, Multi-Factor Authentication
 ### ORY Hydra: OAuth2 & OpenID Connect Server
 
 [ORY Hydra](https://github.com/ory/hydra) is an OpenID Certified™ OAuth2 and
-OpenID Connect Provider can connect to any existing identity database (LDAP, AD,
-KeyCloak, PHP+MySQL, ...) and user interface.
+OpenID Connect Provider easily to be integrated with your frontend.
 
 ### ORY Oathkeeper: Identity & Access Proxy
 


### PR DESCRIPTION
Hydra is not directly able to connect to LDAP and other User-DB-solutions. So that section is misleading as the integration need to be implemented on the UI-interface side.

CC @jaredpreston  Maybe you have a proposal how to characterize hydra a bit better than this?