### PR TITLE
fix: cla-assistant link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,35 @@
 {
   "name": "meta",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "devDependencies": {
+        "ory-prettier-styles": "^1.1.1",
+        "prettier": "2.2.1"
+      }
+    },
+    "node_modules/ory-prettier-styles": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ory-prettier-styles/-/ory-prettier-styles-1.1.1.tgz",
+      "integrity": "sha512-Kv5GUQw0nFDO6w/HcIMNQAh75QeG4ZhrpNuRJaHSlsTvTx9rwpr+bVfeXrhXQsovUW51PF6OvLW3LA0AdDdSzw==",
+      "dev": true
+    },
+    "node_modules/prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    }
+  },
   "dependencies": {
     "ory-prettier-styles": {
       "version": "1.1.1",

--- a/templates/repository/common/CONTRIBUTING.md
+++ b/templates/repository/common/CONTRIBUTING.md
@@ -69,7 +69,8 @@ or the [ORY Chat](https://www.ory.sh/chat).
 - I want to talk to other ORY $PROJECT users.
   [How can I become a part of the community?](#communication)
 
-- I would like to know what I am agreeing to when I contribute to ORY $PROJECT.
+- I would like to know what I am agreeing to when I contribute to ORY
+  $PROJECT.
   Does ORY have
   [a Contributors License Agreement?](https://cla-assistant.io/$REPOSITORY)
 

--- a/templates/repository/common/CONTRIBUTING.md
+++ b/templates/repository/common/CONTRIBUTING.md
@@ -71,7 +71,7 @@ or the [ORY Chat](https://www.ory.sh/chat).
 
 - I would like to know what I am agreeing to when I contribute to ORY $PROJECT.
   Does ORY have
-  [a Contributors License Agreement?](https://cla-assistant.io/ory/)
+  [a Contributors License Agreement?](https://cla-assistant.io/$REPOSITORY)
 
 - I would like updates about new versions of ORY $PROJECT.
   [How are new releases announced?](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)
@@ -144,7 +144,7 @@ At least one review from a maintainer is required for all patches (even patches
 from maintainers).
 
 Before your contributions can be merged you need to sign our
-[Contributor License Agreement](https://cla-assistant.io/ory/).
+[Contributor License Agreement](https://cla-assistant.io/$REPOSITORY).
 
 This agreement defines the terms under which your code is contributed to ORY.
 More specifically it declares that you have the right to, and actually do, grant


### PR DESCRIPTION
$REPOSITORY will be replaced with "ory/repositoryName" and then cla-assistant links in CONTRIBUTING.md will work from there as well.