### PR TITLE
fix: discussions-link sync

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -21,6 +21,8 @@ function sync {
     humanName=$4
     project=$5
     discussions="https://github.com/$project/discussions"
+    metaDiscussions="https://github.com/meta/discussions"
+
     pushBranch="meta-$(date +%m-%d-%y-%H-%M-%S)"
     # set hash as github commit hash, first 8 bytes
     hash=$(echo $GITHUB_SHA | head -c 8)
@@ -47,7 +49,7 @@ function sync {
         if [[ "$project" = "ory/hydra" || $project = "ory/kratos" || $project = "ory/oathkeeper" || $project = "ory/keto" ]]; then
           env -i DISCUSSIONS="$discussions" REPOSITORY="$project" PROJECT="$humanName" /bin/bash -c "envsubst < \"$f\" | sponge \"$f\""
         else
-          env -i DISCUSSIONS="https://github.com/ory/meta/discussions" REPOSITORY="$project" PROJECT="$humanName" /bin/bash -c "envsubst < \"$f\" | sponge \"$f\""
+          env -i DISCUSSIONS="$metaDiscussions" REPOSITORY="$project" PROJECT="$humanName" /bin/bash -c "envsubst < \"$f\" | sponge \"$f\""
         fi
     done
 


### PR DESCRIPTION
Closes https://github.com/ory/meta/issues/85

As discussed in the issue a separate variable for the meta/discussions has been implemented.


A local test with the following testscript produced the desired result: 
Tested with "kratos" and "kratos-selfservice-ui-react-native"

```

#!/bin/bash

set -Eexuo pipefail

    humanName="kratos-selfservice-ui-react-native"
    project=ory/kratos-selfservice-ui-react-native
    discussions="https://github.com/$project/discussions"
    metaDiscussions="https://github.com/meta/discussions"

    for f in $(find "CONTRIBUTING.md" -type f -print); do
        if [[ "$project" = "ory/hydra" || $project = "ory/kratos" || $project = "ory/oathkeeper" || $project = "ory/keto" ]]; then
          env -i DISCUSSIONS="$discussions" REPOSITORY="$project" PROJECT="$humanName" /bin/bash -c "envsubst < \"$f\" | sponge \"$f\""
        else
          env -i DISCUSSIONS="$metaDiscussions" REPOSITORY="$project" PROJECT="$humanName" /bin/bash -c "envsubst < \"$f\" | sponge \"$f\""
        fi
    done
```