### PR TITLE
fix: stray anchor tag

### DIFF
--- a/templates/repository/common/ADOPTERS.md
+++ b/templates/repository/common/ADOPTERS.md
@@ -103,7 +103,7 @@ that your company deserves a spot here, reach out to
 
 We also want to thank all individual contributors
 
-<img src="https://opencollective.com/ory/contributors.svg?width=890&button=false" /></a>
+<a href="https://opencollective.com/ory" target="_blank"><img src="https://opencollective.com/ory/contributors.svg?width=890&button=false" /></a>
 
 as well as all of our backers
 


### PR DESCRIPTION
Removed a stray anchor tag, CI was failing with 
`I found a </a> tag here but there isn't an opening <a ...> tag above.`
I added a proper link to https://opencollective.com/ory. 
Or would it be better to remove the link?