### PR TITLE
fix: format rendered files

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -51,6 +51,9 @@ function sync {
         fi
     done
 
+    # format everything that was rendered
+    (cd "$workdir"; npm ci; npm run format)
+
     # Copy contributing guide to docs if docs exist
     if [ -d "$workdir/docs/docs" ]; then
       cat <<EOF > "$workdir/docs/docs/contributing.md"


### PR DESCRIPTION
Failing CI example: https://app.circleci.com/pipelines/github/ory/keto/1024/workflows/22b24e30-9cda-410a-ac68-b5cceed66294/jobs/7124

This fix ensures that all rendered files (like CONTRIBUTING.md or README.md) are formatted.