### PR TITLE
docs: add list of subsystem prefixes

### DIFF
--- a/templates/repository/common/CONTRIBUTING.md
+++ b/templates/repository/common/CONTRIBUTING.md
@@ -196,7 +196,7 @@ request, go through this checklist:
    command and confirm that it passes.
 1. Run `gofmt -s` (if the project is written in Go).
 1. Ensure that each commit has a subsystem prefix (ex: `controller:`).
-   [List of subsystem prefixes for $PROJECT](https://github.com/ory/$REPOSITORY/labels?q=package)
+   [List of subsystem prefixes for $PROJECT](https://github.com/ory/$REPOSITORY/blob/master/.github/semantic.yml)
    (if applicable).
 
 Pull requests will be treated as "review requests," and maintainers will give

--- a/templates/repository/common/CONTRIBUTING.md
+++ b/templates/repository/common/CONTRIBUTING.md
@@ -196,6 +196,8 @@ request, go through this checklist:
    command and confirm that it passes.
 1. Run `gofmt -s` (if the project is written in Go).
 1. Ensure that each commit has a subsystem prefix (ex: `controller:`).
+   [List of subsystem prefixes for $PROJECT](https://github.com/ory/$REPOSITORY/labels?q=package)
+   (if applicable).
 
 Pull requests will be treated as "review requests," and maintainers will give
 feedback on the style and substance of the patch.


### PR DESCRIPTION
Closes https://github.com/ory/meta/issues/99
This adds a list of possible subsystem prefixes
e.g.
https://github.com/ory/hydra/labels?q=package
https://github.com/ory/kratos/labels?q=package

for the other repos it shows no labels, but it should be self explanatory?
https://github.com/ory/fosite/labels?q=package