### PR TITLE
chore: ORY -> Ory

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -28,125 +28,125 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      - name: Synchronize ORY Hydra
+      - name: Synchronize Ory Hydra
         run: ./scripts/sync-server.sh ory/hydra master Hydra
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
-      - name: Synchronize ORY Keto
+      - name: Synchronize Ory Keto
         run: ./scripts/sync-server.sh ory/keto master Keto
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
-      - name: Synchronize ORY Oathkeeper
+      - name: Synchronize Ory Oathkeeper
         run: ./scripts/sync-server.sh ory/oathkeeper master Oathkeeper
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
   # Synchronize server 
-      - name: Synchronize ORY Kratos
+      - name: Synchronize Ory Kratos
   # runs the sync-server bash script in the Action workers CLI with arguments: $1=workdir (the repository you want to sync) $2=branch $3=humanName
         run: ./scripts/sync-server.sh ory/kratos master Kratos
   # sets the required github token as enviromental variable
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
-      - name: Synchronize ORY Hydra Login, Logout And Consent Node Example
+      - name: Synchronize Ory Hydra Login, Logout And Consent Node Example
         run: |
           ./scripts/sync-library.sh ory/hydra-login-consent-node master "Hydra Login, Logout And Consent Node Example"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
-      - name: Synchronize ORY CLI
+      - name: Synchronize Ory CLI
         run: |
           ./scripts/sync-library.sh ory/cli master CLI
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
   # Synchronize library
-      - name: Synchronize ORY Kratos SelfService UI Node Example
+      - name: Synchronize Ory Kratos SelfService UI Node Example
   # runs the sync-library bash script in the Action workers CLI with arguments: $1=workdir (the repository you want to sync) $2=branch $3=humanName
         run: |
           ./scripts/sync-library.sh ory/kratos-selfservice-ui-node master "Kratos SelfService UI Node Example"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
-      - name: Synchronize ORY Kratos SelfService UI React Native Example
+      - name: Synchronize Ory Kratos SelfService UI React Native Example
         run: |
           ./scripts/sync-library.sh ory/kratos-selfservice-ui-react-native master "Kratos SelfService UI React Native Example"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
-      - name: Synchronize ORY Fosite
+      - name: Synchronize Ory Fosite
         run: ./scripts/sync-library.sh ory/fosite master Fosite
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
-      - name: Synchronize ORY Dockertest
+      - name: Synchronize Ory Dockertest
         run: ./scripts/sync-library.sh ory/dockertest v3 Dockertest
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
-      - name: Synchronize ORY Herodot
+      - name: Synchronize Ory Herodot
         run: ./scripts/sync-library.sh ory/herodot master Herodot
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
-      - name: Synchronize ORY Graceful
+      - name: Synchronize Ory Graceful
         run: ./scripts/sync-library.sh ory/graceful master Graceful
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
-      - name: Synchronize ORY Themes
+      - name: Synchronize Ory Themes
         run: ./scripts/sync-library.sh ory/themes master Themes
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
-      - name: Synchronize ORY Kubernetes Resources
+      - name: Synchronize Ory Kubernetes Resources
         run: ./scripts/sync-library.sh ory/k8s master "Kubernetes Resources"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
-      - name: Synchronize ORY X
+      - name: Synchronize Ory X
         run: ./scripts/sync-library.sh ory/x master X
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
-      - name: Synchronize ORY Web
+      - name: Synchronize Ory Web
         run: ./scripts/sync-library.sh ory/web master Web
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
   # Synchronize action
-      - name: Syncronize ORY Closed Reference Notifier
+      - name: Syncronize Ory Closed Reference Notifier
         # runs the sync-action bash script in the Action workers CLI with arguments: $1=workdir (the repository you want to sync) $2=branch $3=humanName
         run: ./scripts/sync-action.sh ory/closed-reference-notifier master "Closed Reference Notifier"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
-      - name: Syncronize ORY Label Sync Action
+      - name: Syncronize Ory Label Sync Action
         run: ./scripts/sync-action.sh ory/label-sync-action master "Label Sync Action"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
-      - name: Syncronize ORY Milestone Action
+      - name: Syncronize Ory Milestone Action
         run: ./scripts/sync-action.sh ory/milestone-action master "Milestone Action"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
-      - name: Syncronize ORY Prettier Styles Action
+      - name: Syncronize Ory Prettier Styles Action
         run: ./scripts/sync-action.sh ory/prettier-styles master "Prettier Styles"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
-      - name: Syncronize ORY Buildbuf Action
+      - name: Syncronize Ory Buildbuf Action
         run: ./scripts/sync-action.sh ory/build-buf-action main "Buildbuf Action"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
-      - name: Synchronize ORY Works
+      - name: Synchronize Ory Works
         run: ./scripts/sync-library.sh ory/works master Works
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
-      - name: Syncronize ORY Hydra-DB-Growth
+      - name: Syncronize Ory Hydra-DB-Growth
         run: ./scripts/sync-library.sh ory/hydra-db-growth master "Hydra DB Growth"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # meta
 
 A place for reusable code, templates, and documentation required for getting a
-repository in ORY working.
+repository in Ory working.
 
 ## Documentation
 
@@ -23,7 +23,7 @@ will be published using a GitHub Action.
 ## Github Sync action
 
 The [meta scripts](https://github.com/ory/meta/tree/master/scripts) serve to
-synchronize all ORY repositories to a common template, including README,
+synchronize all Ory repositories to a common template, including README,
 CONTRIBUTING, COC, SECURITY, LICENCE and Github Workflows with close to zero
 manual interaction.  
 Depending on repository type (server, library, action) specific templates can be

--- a/templates/repository/common/.github/ISSUE_TEMPLATE/config.yml
+++ b/templates/repository/common/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
-  - name: ORY $PROJECT Forum
+  - name: Ory $PROJECT Forum
     url: https://github.com/$REPOSITORY/discussions
     about: Please ask and answer questions here, show your implementations and discuss ideas.
-  - name: ORY Chat
+  - name: Ory Chat
     url: https://www.ory.sh/chat
-    about: Hang out with other ORY community members and ask and answer questions.
-  - name: ORY Support for Business
+    about: Hang out with other Ory community members and ask and answer questions.
+  - name: Ory Support for Business
     url: https://github.com/ory/open-source-support/blob/master/README.md
-    about: Buy professional support for ORY $PROJECT.
+    about: Buy professional support for Ory $PROJECT.

--- a/templates/repository/common/ADOPTERS.md
+++ b/templates/repository/common/ADOPTERS.md
@@ -1,9 +1,9 @@
 <!--BEGIN ADOPTERS-->
 
-The ORY community stands on the shoulders of individuals, companies, and
+The Ory community stands on the shoulders of individuals, companies, and
 maintainers. We thank everyone involved - from submitting bug reports and
 feature requests, to contributing patches, to sponsoring our work. Our community
-is 1000+ strong and growing rapidly. The ORY stack protects 16.000.000.000+ API
+is 1000+ strong and growing rapidly. The Ory stack protects 16.000.000.000+ API
 requests every month with over 250.000+ active service nodes. We would have
 never been able to achieve this without each and everyone of you!
 
@@ -120,6 +120,6 @@ and past & current supporters (in alphabetical order) on
 Kennedy, Drozzy, Edwin Trejos, Howard Edidin, Ken Adler Oz Haven, Stefan Hans,
 TheCrealm.
 
-<em>\* Uses one of ORY's major projects in production.</em>
+<em>\* Uses one of Ory's major projects in production.</em>
 
 <!--END ADOPTERS-->

--- a/templates/repository/common/PROJECTS.md
+++ b/templates/repository/common/PROJECTS.md
@@ -8,40 +8,40 @@ design:
 - Scales without effort
 - Minimize room for human and network errors
 
-ORY's architecture designed to run best on a Container Orchestration Systems
+Ory's architecture designed to run best on a Container Orchestration Systems
 such as Kubernetes, CloudFoundry, OpenShift, and similar projects. Binaries are
 small (5-15MB) and available for all popular processor types (ARM, AMD64, i386)
 and operating systems (FreeBSD, Linux, macOS, Windows) without system
 dependencies (Java, Node, Ruby, libxml, ...).
 
-### ORY Kratos: Identity and User Infrastructure and Management
+### Ory Kratos: Identity and User Infrastructure and Management
 
-[ORY Kratos](https://github.com/ory/kratos) is an API-first Identity and User
+[Ory Kratos](https://github.com/ory/kratos) is an API-first Identity and User
 Management system that is built according to
 [cloud architecture best practices](https://www.ory.sh/docs/next/ecosystem/software-architecture-philosophy).
 It implements core use cases that almost every software application needs to
 deal with: Self-service Login and Registration, Multi-Factor Authentication
 (MFA/2FA), Account Recovery and Verification, Profile and Account Management.
 
-### ORY Hydra: OAuth2 & OpenID Connect Server
+### Ory Hydra: OAuth2 & OpenID Connect Server
 
-[ORY Hydra](https://github.com/ory/hydra) is an OpenID Certified™ OAuth2 and
+[Ory Hydra](https://github.com/ory/hydra) is an OpenID Certified™ OAuth2 and
 OpenID Connect Provider which easily connects to any existing identity system by
 writing a tiny "bridge" application. Gives absolute control over user interface
 and user experience flows.
 
-### ORY Oathkeeper: Identity & Access Proxy
+### Ory Oathkeeper: Identity & Access Proxy
 
-[ORY Oathkeeper](https://github.com/ory/oathkeeper) is a BeyondCorp/Zero Trust
+[Ory Oathkeeper](https://github.com/ory/oathkeeper) is a BeyondCorp/Zero Trust
 Identity & Access Proxy (IAP) with configurable authentication, authorization,
 and request mutation rules for your web services: Authenticate JWT, Access
 Tokens, API Keys, mTLS; Check if the contained subject is allowed to perform the
 request; Encode resulting content into custom headers (`X-User-ID`), JSON Web
 Tokens and more!
 
-### ORY Keto: Access Control Policies as a Server
+### Ory Keto: Access Control Policies as a Server
 
-[ORY Keto](https://github.com/ory/keto) is a policy decision point. It uses a
+[Ory Keto](https://github.com/ory/keto) is a policy decision point. It uses a
 set of access control policies, similar to AWS IAM Policies, in order to
 determine whether a subject (user, application, service, car, ...) is authorized
 to perform a certain action on a resource.

--- a/templates/repository/library/.github/pull_request_template.md
+++ b/templates/repository/library/.github/pull_request_template.md
@@ -8,7 +8,7 @@ If this change neither resolves an existing issue nor has sign-off from one of t
 chance substantial changes will be requested or that the changes will be rejected.
 
 You can discuss changes with maintainers either in the Github Discusssions in this repository or
-join the [ORY Chat](https://www.ory.sh/chat).
+join the [Ory Chat](https://www.ory.sh/chat).
 -->
 
 ## Proposed changes

--- a/templates/repository/server/.github/pull_request_template.md
+++ b/templates/repository/server/.github/pull_request_template.md
@@ -8,7 +8,7 @@ If this change neither resolves an existing issue nor has sign-off from one of t
 chance substantial changes will be requested or that the changes will be rejected.
 
 You can discuss changes with maintainers either in the Github Discusssions in this repository or
-join the [ORY Chat](https://www.ory.sh/chat).
+join the [Ory Chat](https://www.ory.sh/chat).
 -->
 
 ## Proposed changes


### PR DESCRIPTION
Finally changing all the templates in /meta to from ORY to Ory. 
This will probably crop up over time, but I try to take care of it whenever possible. 
Next up would be ory/docs and then the individual repos.