### PR TITLE
fix: remove global CODEOWNER file

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -52,7 +52,7 @@ function sync {
         fi
     done
 
-    # format everything that was rendered, only if
+    # format everything that was rendered, only if package.json exists
     (cd "$workdir"; if test -f package.json; then (npm ci; npm run format); else true; fi)
 
     # Copy contributing guide to docs if docs exist

--- a/templates/repository/common/.github/CODEOWNER
+++ b/templates/repository/common/.github/CODEOWNER
@@ -1,1 +1,0 @@
-*       @ory/maintainers


### PR DESCRIPTION
Will add individual CODEOWNER files in each repo. The default of what was previously there should stay as our sync script does not delete files.