### PR TITLE
fix: Limit OpenCollective contributor image size

### DIFF
--- a/templates/repository/common/ADOPTERS.md
+++ b/templates/repository/common/ADOPTERS.md
@@ -80,7 +80,7 @@ that your company deserves a spot here, reach out to
             <td align="center"><img height="32px" src="https://raw.githubusercontent.com/ory/meta/master/static/adopters/sainsburys.svg" alt="Sainsbury's"></td>
             <td><a href="https://www.sainsburys.co.uk/">sainsburys.co.uk</a></td>
         </tr>
-                <tr>
+        <tr>
             <td>Adopter *</td>
             <td>Contraste</td>
             <td align="center"><img height="32px" src="https://raw.githubusercontent.com/ory/meta/master/static/adopters/contraste.svg" alt="Contraste"></td>
@@ -127,7 +127,7 @@ that your company deserves a spot here, reach out to
 
 We also want to thank all individual contributors
 
-<a href="https://opencollective.com/ory" target="_blank"><img src="https://opencollective.com/ory/contributors.svg?width=890&button=false" /></a>
+<a href="https://opencollective.com/ory" target="_blank"><img src="https://opencollective.com/ory/contributors.svg?width=890&limit=714&button=false" /></a>
 
 as well as all of our backers
 


### PR DESCRIPTION
The OpenCollective individual contributor badge was being dropped by Github Camo for being too large. This PR limits the number of profile pics returned, reducing the size of the image. GitHub Camo seems to limit at 5Mb, and the limited image comes out to a bit over 4.5MB, which should be just enough wiggle room for if someone moves up the rankings or changes profile pictures.

See https://github.com/ory/kratos/pull/1857