### PR TITLE
fix: add docs to sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -54,8 +54,8 @@ jobs:
         run: |
           ./scripts/sync-library.sh ory/hydra-login-consent-node master "Hydra Login, Logout And Consent Node Example"
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}      
-          
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
+
       - name: Synchronize Ory Documentation
         run: |
           ./scripts/sync-library.sh ory/docs master "Documentation"

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -54,6 +54,12 @@ jobs:
         run: |
           ./scripts/sync-library.sh ory/hydra-login-consent-node master "Hydra Login, Logout And Consent Node Example"
         env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}      
+          
+      - name: Synchronize Ory Documentation
+        run: |
+          ./scripts/sync-library.sh ory/docs master "Documentation"
+        env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_AENEASR }}
 
       - name: Synchronize Ory CLI


### PR DESCRIPTION
This would add CONTRIBUTING to the docs and a proper readme. 


Do we need to add the 
```
<!--BEGIN ADOPTERS-->
<!--END ADOPTERS--

<!--BEGIN ECOSYSTEM-->
<!--END ECOSYSTEM-->
```
to the README? 

- Happy to open another issue to make the README look more in line to ory/kratos etc. 


Also we can probably delete this part from the [sync.sh](https://github.com/ory/meta/blob/master/scripts/sync.sh)? 

```
    # Copy contributing guide to docs if docs exist
    if [ -d "$workdir/docs/docs" ]; then
      cat <<EOF > "$workdir/docs/docs/contributing.md"
```

I would use CONTRIBUTING and combine it with 
https://github.com/ory/docs/blob/master/docs/ecosystem/contributing.md
to make a "general" contributing guide, that is in parts automated, in parts has some general sections added. 
