### PR TITLE
fix: use correct discussions repo

### DIFF
--- a/templates/repository/common/.github/ISSUE_TEMPLATE/config.yml
+++ b/templates/repository/common/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ory $PROJECT Forum
-    url: https://github.com/$REPOSITORY/discussions
+    url: $DISCUSSIONS
     about:
       Please ask and answer questions here, show your implementations and
       discuss ideas.


### PR DESCRIPTION
This changes the forum URL to  $DISCUSSIONS which will always use the Ory Org discussions if there is none on the repo (i.e. for all repos except kratos,hydra,oathkeeper,keto).

Closes https://github.com/ory/dockertest/issues/361