### PR TITLE
feat: conventional commits v2

### DIFF
--- a/templates/repository/common/.github/workflows/conventional_commits.yml
+++ b/templates/repository/common/.github/workflows/conventional_commits.yml
@@ -8,6 +8,7 @@ on:
       - ready_for_review
       - reopened
       - synchronize
+  # pull_request: # for debugging, uses config in local branch but supports only Pull Requests from this repo
 
 jobs:
   main:

--- a/templates/repository/common/.github/workflows/conventional_commits.yml
+++ b/templates/repository/common/.github/workflows/conventional_commits.yml
@@ -14,7 +14,6 @@ on:
       - opened
       - ready_for_review
       - reopened
-      - synchronize
   # pull_request: # for debugging, uses config in local branch but supports only Pull Requests from this repo
 
 jobs:

--- a/templates/repository/common/.github/workflows/conventional_commits.yml
+++ b/templates/repository/common/.github/workflows/conventional_commits.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   main:
-    name: validate PR title
+    name: Validate PR title
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/templates/repository/common/.github/workflows/conventional_commits.yml
+++ b/templates/repository/common/.github/workflows/conventional_commits.yml
@@ -1,4 +1,4 @@
-name: Conventional Commits
+name: Conventional commits
 
 on:
   pull_request_target:

--- a/templates/repository/common/.github/workflows/conventional_commits.yml
+++ b/templates/repository/common/.github/workflows/conventional_commits.yml
@@ -3,27 +3,11 @@ name: Conventional commits
 # This GitHub CI Action enforces that pull request titles follow conventional commits.
 # More info at https://www.conventionalcommits.org.
 #
-# The action defines Ory-specific defaults for commit titles and scopes
-# in variables in SCREAMING_SNAKE_CASE in the github-script actions below.
-#
-# Configuration: in your repo, create a file ".github/conventional_commits.json".
-# Example content:
-#
-# {
-#   "types": ["type1", "type2"],
-#   "addTypes": ["type3", "type4"],
-#   "scopes": ["scope1", "scope2"],
-#   "addScopes": ["scope3", "scope4"],
-#   "requireScope": true
-# }
-#
-# All keys are optional, remove the ones you don't need.
-#
-# types: overrides the default types
-# addTypes: adds the given types to the set of default types
-# scopes: overrides the default scopes
-# addScopes: adds the given scopes to the set of default scopes
-# requireScope: enforces a scope in pull requests titles (default: false)
+# The action defines Ory-specific defaults for commit titles and scopes.
+# You see them below. They apply to all Ory repos.
+# Your repository can add or replace elements via a configuration file.
+# Path for that below as well.
+# More info at https://github.com/ory/ci/blob/master/conventional_commit_config/README.md
 
 on:
   pull_request_target:
@@ -37,93 +21,38 @@ on:
 
 jobs:
   main:
-    name: Validate PR title
+    name: validate PR title
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - id: load_config
-        uses: actions/github-script@v6
+      - id: config
+        uses: ory/ci/conventional_commit_config@master
         with:
-          script: |
-            const CONFIG_PATH = ".github/conventional_commits.json"
-            console.log(`looking for config file ${CONFIG_PATH}`)
-            try {
-              var configText = require("fs").readFileSync(CONFIG_PATH, "utf8")
-            } catch (e) {
-              console.log("no config file")
-              return {}
-            }
-            try {
-              var config = JSON.parse(configText)
-            } catch (e) {
-              console.log(`ERROR: invalid JSON in ${CONFIG_PATH}:`, e)
-              return {}
-            }
-            console.log(`config found: ${require("util").inspect(config)}`)
-            return config
-
-      - id: load_types
-        uses: actions/github-script@v6
-        with:
-          result-encoding: string
-          script: |
-            const DEFAULT_TYPES = `
-              feat
-              fix
-              revert
-              docs
-              style
-              refactor
-              test
-              build
-              autogen
-              security
-              ci
-              chore
-            `
-            const config = ${{ steps.load_config.outputs.result }}
-            const types = config.types ? config.types.join("\n") : DEFAULT_TYPES
-            const result = config.addTypes ? types + "\n" + config.addTypes.join("\n") : types
-            console.log(`allowed types:\n${result}`)
-            return result
-
-      - id: load_scopes
-        uses: actions/github-script@v6
-        with:
-          result-encoding: string
-          script: |
-            const DEFAULT_SCOPES = `
-              blog
-              cms
-              deps
-              docs
-              home
-              stats
-            `
-            const config = ${{ steps.load_config.outputs.result }}
-            let scopes = config.scopes ? config.scopes.join("\n") : DEFAULT_SCOPES
-            const result = config.addScopes ? scopes + "\n" + config.addScopes.join("\n") : scopes
-            console.log(`allowed scopes:\n${result}`)
-            return result
-
-      - id: load_require_scope
-        uses: actions/github-script@v6
-        with:
-          result-encoding: string
-          script: |
-            const DEFAULT_REQUIRE_SCOPE = false
-            const config = ${{ steps.load_config.outputs.result }}
-            const result = config.requireScope || DEFAULT_REQUIRE_SCOPE
-            console.log(`require scope: ${result}`)
-            return result
-
+          config_path: .github/conventional_commits.json
+          default_types: |
+            feat
+            fix
+            revert
+            docs
+            style
+            refactor
+            test
+            build
+            autogen
+            security
+            ci
+            chore
+          default_scopes: |
+            defaultScope1
+            defaultScope2
+          default_require_scope: false
       - uses: amannn/action-semantic-pull-request@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          types: ${{ steps.load_types.outputs.result }}
-          scopes: ${{ steps.load_scopes.outputs.result }}
-          requireScope: ${{ steps.load_require_scope.outputs.result }}
+          types: ${{ steps.config.outputs.types }}
+          scopes: ${{ steps.config.outputs.scopes }}
+          requireScope: ${{ steps.config.outputs.requireScope }}
           subjectPattern: ^(?![A-Z]).+$
           subjectPatternError: |
             The subject should start with a lowercase letter, yours is uppercase:

--- a/templates/repository/common/.github/workflows/conventional_commits.yml
+++ b/templates/repository/common/.github/workflows/conventional_commits.yml
@@ -1,75 +1,20 @@
-name: Conventional commits
+name: Conventional Commits
 
 on:
-  pull_request_target: # enable Pull Requests from forks, uses config from master branch
-    types: [opened, edited, reopened, ready_for_review]
-  # pull_request: # for debugging, uses config in local branch but supports only Pull Requests from this repo
+  pull_request_target:
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
 
 jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4
-        id: check-title
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - uses: kevgo/action-test@main
         with:
-          types: |
-            feat
-            fix
-            revert
-            docs
-            style
-            refactor
-            test
-            build
-            autogen
-            security
-            ci
-            chore
-
-          scopes: |
-            blog
-            cms
-            deps
-            docs
-            home
-            hydra
-            keto
-            kratos
-            stats
-
-          requireScope: false
-
-          # Configure which scopes are disallowed in PR titles. For instance by setting
-          # the value below, `chore(release): ...` and `ci(e2e,release): ...` will be rejected.
-          # disallowScopes: |
-          #   release
-
-          # Configure additional validation for the subject based on a regex.
-          # This example ensures the subject doesn't start with an uppercase character.
-          subjectPattern: ^(?![A-Z]).+$
-
-          # If `subjectPattern` is configured, you can use this property to override
-          # the default error message that is shown when the pattern doesn't match.
-          # The variables `subject` and `title` can be used within the message.
-          subjectPatternError: |
-            The subject should start with a lowercase letter, yours is uppercase:
-            "{subject}"
-
-          # If the PR contains one of these labels, the validation is skipped.
-          # Multiple labels can be separated by newlines.
-          # If you want to rerun the validation when labels change, you might want
-          # to use the `labeled` and `unlabeled` event triggers in your workflow.
-          # ignoreLabels: |
-          #   bot
-          #   ignore-semantic-pull-request
-
-          # For work-in-progress PRs you can typically use draft pull requests
-          # from GitHub. However, private repositories on the free plan don't have
-          # this option and therefore this action allows you to opt-in to using the
-          # special "[WIP]" prefix to indicate this state. This will avoid the
-          # validation of the PR title and the pull request checks remain pending.
-          # Note that a second check will be reported if this is enabled.
-          # wip: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/repository/common/.github/workflows/conventional_commits.yml
+++ b/templates/repository/common/.github/workflows/conventional_commits.yml
@@ -3,10 +3,8 @@ name: Conventional commits
 # This GitHub CI Action enforces that pull request titles follow conventional commits.
 # More info at https://www.conventionalcommits.org.
 #
-# The action defines Ory-specific defaults for commit titles and scopes.
-# You see them below. They apply to all Ory repos.
-# Your repository can add or replace elements via a configuration file.
-# Path for that below as well.
+# The Ory-wide defaults for commit titles and scopes are below.
+# Your repository can add/replace elements via a configuration file at the path below.
 # More info at https://github.com/ory/ci/blob/master/conventional_commit_config/README.md
 
 on:

--- a/templates/repository/common/.github/workflows/conventional_commits.yml
+++ b/templates/repository/common/.github/workflows/conventional_commits.yml
@@ -6,7 +6,7 @@ name: Conventional commits
 # The action defines Ory-specific defaults for commit titles and scopes
 # in variables in SCREAMING_SNAKE_CASE in the github-script actions below.
 #
-# Configuration: create a file ".github/conventional_commits.json".
+# Configuration: in your repo, create a file ".github/conventional_commits.json".
 # Example content:
 #
 # {
@@ -17,7 +17,7 @@ name: Conventional commits
 #   "requireScope": true
 # }
 #
-# Remove keys that you don't need.
+# All keys are optional, remove the ones you don't need.
 #
 # types:        overrides the default types
 # addTypes:     adds the given types to the set of default types

--- a/templates/repository/common/.github/workflows/conventional_commits.yml
+++ b/templates/repository/common/.github/workflows/conventional_commits.yml
@@ -1,5 +1,30 @@
 name: Conventional commits
 
+# This GitHub CI Action enforces that pull request titles follow conventional commits.
+# More info at https://www.conventionalcommits.org.
+#
+# The action defines Ory-specific defaults for commit titles and scopes
+# in variables in SCREAMING_SNAKE_CASE in the github-script actions below.
+#
+# Configuration: create a file ".github/conventional_commits.json".
+# Example content:
+#
+# {
+#   "types": ["type1", "type2"],
+#   "addTypes": ["type3", "type4"],
+#   "scopes": ["scope1", "scope2"],
+#   "addScopes": ["scope3", "scope4"],
+#   "requireScope": true
+# }
+#
+# Remove keys that you don't need.
+#
+# types:        overrides the default types
+# addTypes:     adds the given types to the set of default types
+# scopes:       overrides the default scopes
+# addScopes:    adds the given scopes to the set of default scopes
+# requireScope: enforces a scope in pull requests titles (default: false)
+
 on:
   pull_request_target:
     types:
@@ -16,6 +41,90 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ory/ci/conventional_commits@main
+      - id: load_config
+        uses: actions/github-script@v6
         with:
+          script: |
+            const CONFIG_PATH = ".github/conventional_commits.json"
+            console.log(`looking for config file ${CONFIG_PATH}`)
+            try {
+              var configText = require("fs").readFileSync(CONFIG_PATH, "utf8")
+            } catch (e) {
+              console.log("no config file")
+              return {}
+            }
+            try {
+              var config = JSON.parse(configText)
+            } catch (e) {
+              console.log(`ERROR: invalid JSON in ${CONFIG_PATH}:`, e)
+              return {}
+            }
+            console.log(`config found: ${require("util").inspect(config)}`)
+            return config
+
+      - id: load_types
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const DEFAULT_TYPES = `
+              feat
+              fix
+              revert
+              docs
+              style
+              refactor
+              test
+              build
+              autogen
+              security
+              ci
+              chore
+            `
+            const config = ${{ steps.load_config.outputs.result }}
+            const types = config.types ? config.types.join("\n") : DEFAULT_TYPES
+            const result = config.addTypes ? types + "\n" + config.addTypes.join("\n") : types
+            console.log(`allowed types:\n${result}`)
+            return result
+
+      - id: load_scopes
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const DEFAULT_SCOPES = `
+              blog
+              cms
+              deps
+              docs
+              home
+              stats
+            `
+            const config = ${{ steps.load_config.outputs.result }}
+            let scopes = config.scopes ? config.scopes.join("\n") : DEFAULT_SCOPES
+            const result = config.addScopes ? scopes + "\n" + config.addScopes.join("\n") : scopes
+            console.log(`allowed scopes:\n${result}`)
+            return result
+
+      - id: load_require_scope
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const DEFAULT_REQUIRE_SCOPE = false
+            const config = ${{ steps.load_config.outputs.result }}
+            const result = config.requireScope || DEFAULT_REQUIRE_SCOPE
+            console.log(`require scope: ${result}`)
+            return result
+
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: ${{ steps.load_types.outputs.result }}
+          scopes: ${{ steps.load_scopes.outputs.result }}
+          requireScope: ${{ steps.load_require_scope.outputs.result }}
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject should start with a lowercase letter, yours is uppercase:
+            "{subject}"

--- a/templates/repository/common/.github/workflows/conventional_commits.yml
+++ b/templates/repository/common/.github/workflows/conventional_commits.yml
@@ -40,8 +40,8 @@ jobs:
             ci
             chore
           default_scopes: |
-            defaultScope1
-            defaultScope2
+            deps
+            docs
           default_require_scope: false
       - uses: amannn/action-semantic-pull-request@v4
         env:

--- a/templates/repository/common/.github/workflows/conventional_commits.yml
+++ b/templates/repository/common/.github/workflows/conventional_commits.yml
@@ -19,10 +19,10 @@ name: Conventional commits
 #
 # All keys are optional, remove the ones you don't need.
 #
-# types:        overrides the default types
-# addTypes:     adds the given types to the set of default types
-# scopes:       overrides the default scopes
-# addScopes:    adds the given scopes to the set of default scopes
+# types: overrides the default types
+# addTypes: adds the given types to the set of default types
+# scopes: overrides the default scopes
+# addScopes: adds the given scopes to the set of default scopes
 # requireScope: enforces a scope in pull requests titles (default: false)
 
 on:

--- a/templates/repository/common/.github/workflows/conventional_commits.yml
+++ b/templates/repository/common/.github/workflows/conventional_commits.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: kevgo/action-test@main
+      - uses: ory/ci/conventional_commits@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Here comes v2 of the new system to enforce conventional commit style on pull requests. Big thanks to @zepatrik for providing detailed feedback about what didn't work with v1, providing pointers to a better solution, and even going the extra mile and submitting a possible upstream fix! 🚀 

V2 finally provides the right abstractions that Ory needs (I think):
- a centralized Ory-specific set of default titles and scopes
  - most repos can use those and don't need any custom config files at all
- a generic workflow definition that can be pushed to all repos as often as we want without overriding customizations
- ability for individual repos to override particular settings via a separate file
- ability to _add_ titles and scopes to the existing sets

One problem with all previous versions was that the set of allowed titles and scopes was stored redundantly in every repo (in `.github/semantic.yml`). This is hard to maintain, for example when adding a new default scope we have to update this file in every repo. This problem no longer exists in v2.

Please pay extra attention to the set of default titles and scopes. I'm not sure what I have so far is the correct set that is used by all Ory repos. Thanks!

This is used by https://github.com/ory/ci/pull/94.