### PR TITLE
feat: test changes to be synced on CI before syncing them

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,3 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: make test
+      - run: |
+          source ./scripts/sync.sh
+          install_dependencies_on_ci
+          configure_git_on_ci
+          workspace=$(create_workspace)
+          replicate_all "$workspace" "commit"


### PR DESCRIPTION
Since we have tests for the sync action now, and will push a good amount of changes through the sync mechanism, it might make sense to test-drive the sync and identify any issues before the sync runs for real.