### PR TITLE
docs: remove mention of CircleCI

### DIFF
--- a/templates/repository/common/CONTRIBUTING.md
+++ b/templates/repository/common/CONTRIBUTING.md
@@ -185,10 +185,6 @@ request, go through this checklist:
    Please refer to this
    [list of prefixes for $PROJECT](https://github.com/$REPOSITORY/blob/master/.github/semantic.yml)
    for an overview.
-1. Sign-up with CircleCI so that it has access to your repository with the
-   branch containing your PR. Simply creating a CircleCI account is sufficient
-   for the CI jobs to run, you do not need to setup a CircleCI project for the
-   branch.
 
 If a pull request is not ready to be reviewed yet
 [it should be marked as a "Draft"](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request).


### PR DESCRIPTION
Now that CircleCI is no longer used, contributors are no longer required to create a CircleCI account.