### PR TITLE
chore: remove old headers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,3 @@
-<!--
-
-Thank you for contributing changes to this document! Because we use a central repository
-to synchronize this file across all our repositories, make sure to make your edits
-in the correct file, which you can find here:
-
-https://github.com/ory/meta/blob/master/templates/repository/CONTRIBUTING.md
-
--->
-
 # Contributing to ORY {{Project}}
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,13 +1,3 @@
-<!--
-
-Thank you for contributing changes to this document! Because we use a central repository
-to synchronize this file across all our repositories, make sure to make your edits
-in the correct file, which you can find here:
-
-https://github.com/ory/meta/blob/master/templates/repository/SECURITY.md
-
--->
-
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 

--- a/templates/repository/common/CONTRIBUTING.md
+++ b/templates/repository/common/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contribute to Ory $PROJECT
+# Contribute to Ory $PROJECT<!-- omit in toc -->
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/templates/repository/common/CONTRIBUTING.md
+++ b/templates/repository/common/CONTRIBUTING.md
@@ -1,14 +1,4 @@
-<!--
-
-Thank you for contributing changes to this document! Because we use a central repository
-to synchronize this file across all our repositories, make sure to make your edits
-in the correct file, which you can find here:
-
-https://github.com/ory/meta/blob/master/templates/repository/common/CONTRIBUTING.md
-
--->
-
-# Contribute to Ory $PROJECT<!-- omit in toc -->
+# Contribute to Ory $PROJECT
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/templates/repository/common/SECURITY.md
+++ b/templates/repository/common/SECURITY.md
@@ -1,13 +1,3 @@
-<!--
-
-Thank you for contributing changes to this document! Because we use a central repository
-to synchronize this file across all our repositories, make sure to make your edits
-in the correct file, which you can find here:
-
-https://github.com/ory/meta/blob/master/templates/repository/SECURITY.md
-
--->
-
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 


### PR DESCRIPTION
These headers were hard-coded and showed up even in the original file. Since https://github.com/ory/meta/pull/171 shipped, they are no longer necessary.