### PR TITLE
chore: unified formatting for all repos

### DIFF
--- a/templates/repository/common/.github/workflows/format.yml
+++ b/templates/repository/common/.github/workflows/format.yml
@@ -1,0 +1,17 @@
+name: Format
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - run: make format
+      - name: Indicate formatting issues
+        run: git diff HEAD --exit-code --color


### PR DESCRIPTION
All repos have the same formatting now, so we can move this into the meta repo.