### PR TITLE
chore: update Ory CLI with breaking changes to the format task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 format: .bin/ory .bin/shfmt node_modules  # formats the source code
 	echo formatting ...
-	.bin/ory dev headers license
+	.bin/ory dev headers copyright
 	.bin/shfmt --write .
 	npm exec -- prettier --write .
 
@@ -21,7 +21,7 @@ test: .bin/shellcheck .bin/shfmt node_modules  # runs all linters
 
 .bin/ory: Makefile
 	echo installing Ory CLI ...
-	curl https://raw.githubusercontent.com/ory/meta/master/install.sh | bash -s -- -b .bin ory v0.1.47
+	curl https://raw.githubusercontent.com/ory/meta/master/install.sh | bash -s -- -b .bin ory v0.1.48
 	touch .bin/ory
 
 .bin/shellcheck: Makefile

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 format: .bin/ory .bin/shfmt node_modules  # formats the source code
 	echo formatting ...
-	.bin/ory dev headers copyright
+	.bin/ory dev headers copyright --type=open-source
 	.bin/shfmt --write .
 	npm exec -- prettier --write .
 

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -254,7 +254,7 @@ function install_dependencies_on_ci {
 	header "INSTALLING DEPENDENCIES"
 	sudo apt-get update -y
 	sudo apt-get install -y moreutils gettext-base
-	curl https://raw.githubusercontent.com/ory/meta/master/install.sh | bash -s -- -b .bin ory v0.1.47
+	curl https://raw.githubusercontent.com/ory/meta/master/install.sh | bash -s -- -b .bin ory v0.1.48
 }
 
 # pushes the committed changes from the local Git client to GitHub


### PR DESCRIPTION
https://github.com/ory/cli/pull/257 changed the name of the command to add copyright headers to files. Ship this PR after Ory CLI v0.1.48 ships.