### PR TITLE
fix: update sync action to node16

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -18,8 +18,8 @@ jobs:
     name: Synchronize Repositories
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: webfactory/ssh-agent@v0.4.1
+      - uses: actions/checkout@v3
+      - uses: webfactory/ssh-agent@v0.7.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "devDependencies": {
         "license-checker": "^25.0.1",
-        "ory-prettier-styles": "1.3.0",
         "prettier": "2.7.1",
         "prettier-plugin-packagejson": "^2.2.18",
         "text-runner": "5.0.2"
@@ -1214,12 +1213,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/ory-prettier-styles": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ory-prettier-styles/-/ory-prettier-styles-1.3.0.tgz",
-      "integrity": "sha512-Vfn0G6CyLaadwcCamwe1SQCf37ZQfBDgMrhRI70dE/2fbE3Q43/xu7K5c32I5FGt/EliroWty5yBjmdkj0eWug==",
-      "dev": true
     },
     "node_modules/os-homedir": {
       "version": "1.0.2",
@@ -2846,12 +2839,6 @@
       "requires": {
         "mimic-fn": "^2.1.0"
       }
-    },
-    "ory-prettier-styles": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ory-prettier-styles/-/ory-prettier-styles-1.3.0.tgz",
-      "integrity": "sha512-Vfn0G6CyLaadwcCamwe1SQCf37ZQfBDgMrhRI70dE/2fbE3Q43/xu7K5c32I5FGt/EliroWty5yBjmdkj0eWug==",
-      "dev": true
     },
     "os-homedir": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,8 @@
   "scripts": {
     "text-run": "text-run"
   },
-  "prettier": "ory-prettier-styles",
   "devDependencies": {
     "license-checker": "^25.0.1",
-    "ory-prettier-styles": "1.3.0",
     "prettier": "2.7.1",
     "prettier-plugin-packagejson": "^2.2.18",
     "text-runner": "5.0.2"

--- a/templates/repository/common/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/templates/repository/common/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -9,24 +9,18 @@ body:
   - attributes:
       label: "Preflight checklist"
       options:
-        - label:
-            "I could not find a solution in the existing issues, docs, nor
+        - label: "I could not find a solution in the existing issues, docs, nor
             discussions."
           required: true
-        - label:
-            "I agree to follow this project's [Code of
+        - label: "I agree to follow this project's [Code of
             Conduct](https://github.com/$REPOSITORY/blob/master/CODE_OF_CONDUCT.md)."
           required: true
-        - label:
-            "I have read and am following this repository's [Contribution
+        - label: "I have read and am following this repository's [Contribution
             Guidelines](https://github.com/$REPOSITORY/blob/master/CONTRIBUTING.md)."
           required: true
-        - label:
-            "This issue affects my [Ory Network](https://www.ory.sh/) project."
-        - label:
-            "I have joined the [Ory Community Slack](https://slack.ory.sh)."
-        - label:
-            "I am signed up to the [Ory Security Patch
+        - label: "This issue affects my [Ory Network](https://www.ory.sh/) project."
+        - label: "I have joined the [Ory Community Slack](https://slack.ory.sh)."
+        - label: "I am signed up to the [Ory Security Patch
             Newsletter](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)."
     id: checklist
     type: checkboxes
@@ -53,8 +47,7 @@ body:
     validations:
       required: true
   - attributes:
-      description:
-        "Please copy and paste any relevant log output. This will be
+      description: "Please copy and paste any relevant log output. This will be
         automatically formatted into code, so no need for backticks. Please
         redact any sensitive information"
       label: "Relevant log output"

--- a/templates/repository/common/.github/ISSUE_TEMPLATE/DESIGN-DOC.yml
+++ b/templates/repository/common/.github/ISSUE_TEMPLATE/DESIGN-DOC.yml
@@ -1,5 +1,4 @@
-description:
-  "A design document is needed for non-trivial changes to the code base."
+description: "A design document is needed for non-trivial changes to the code base."
 labels:
   - rfc
 name: "Design Document"
@@ -20,24 +19,18 @@ body:
   - attributes:
       label: "Preflight checklist"
       options:
-        - label:
-            "I could not find a solution in the existing issues, docs, nor
+        - label: "I could not find a solution in the existing issues, docs, nor
             discussions."
           required: true
-        - label:
-            "I agree to follow this project's [Code of
+        - label: "I agree to follow this project's [Code of
             Conduct](https://github.com/$REPOSITORY/blob/master/CODE_OF_CONDUCT.md)."
           required: true
-        - label:
-            "I have read and am following this repository's [Contribution
+        - label: "I have read and am following this repository's [Contribution
             Guidelines](https://github.com/$REPOSITORY/blob/master/CONTRIBUTING.md)."
           required: true
-        - label:
-            "This issue affects my [Ory Network](https://www.ory.sh/) project."
-        - label:
-            "I have joined the [Ory Community Slack](https://slack.ory.sh)."
-        - label:
-            "I am signed up to the [Ory Security Patch
+        - label: "This issue affects my [Ory Network](https://www.ory.sh/) project."
+        - label: "I have joined the [Ory Community Slack](https://slack.ory.sh)."
+        - label: "I am signed up to the [Ory Security Patch
             Newsletter](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)."
     id: checklist
     type: checkboxes

--- a/templates/repository/common/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
+++ b/templates/repository/common/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
@@ -1,5 +1,4 @@
-description:
-  "Suggest an idea for this project without a plan for implementation"
+description: "Suggest an idea for this project without a plan for implementation"
 labels:
   - feat
 name: "Feature Request"
@@ -13,30 +12,23 @@ body:
   - attributes:
       label: "Preflight checklist"
       options:
-        - label:
-            "I could not find a solution in the existing issues, docs, nor
+        - label: "I could not find a solution in the existing issues, docs, nor
             discussions."
           required: true
-        - label:
-            "I agree to follow this project's [Code of
+        - label: "I agree to follow this project's [Code of
             Conduct](https://github.com/$REPOSITORY/blob/master/CODE_OF_CONDUCT.md)."
           required: true
-        - label:
-            "I have read and am following this repository's [Contribution
+        - label: "I have read and am following this repository's [Contribution
             Guidelines](https://github.com/$REPOSITORY/blob/master/CONTRIBUTING.md)."
           required: true
-        - label:
-            "This issue affects my [Ory Network](https://www.ory.sh/) project."
-        - label:
-            "I have joined the [Ory Community Slack](https://slack.ory.sh)."
-        - label:
-            "I am signed up to the [Ory Security Patch
+        - label: "This issue affects my [Ory Network](https://www.ory.sh/) project."
+        - label: "I have joined the [Ory Community Slack](https://slack.ory.sh)."
+        - label: "I am signed up to the [Ory Security Patch
             Newsletter](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)."
     id: checklist
     type: checkboxes
   - attributes:
-      description:
-        "Is your feature request related to a problem? Please describe."
+      description: "Is your feature request related to a problem? Please describe."
       label: "Describe your problem"
       placeholder:
         "A clear and concise description of what the problem is. Ex. I'm always
@@ -70,8 +62,7 @@ body:
     validations:
       required: true
   - attributes:
-      description:
-        "Add any other context or screenshots about the feature request here."
+      description: "Add any other context or screenshots about the feature request here."
       label: Additional Context
     id: additional
     type: textarea

--- a/templates/repository/common/.github/ISSUE_TEMPLATE/config.yml
+++ b/templates/repository/common/.github/ISSUE_TEMPLATE/config.yml
@@ -2,10 +2,8 @@ blank_issues_enabled: false
 contact_links:
   - name: Ory $PROJECT Forum
     url: $DISCUSSIONS
-    about:
-      Please ask and answer questions here, show your implementations and
+    about: Please ask and answer questions here, show your implementations and
       discuss ideas.
   - name: Ory Chat
     url: https://www.ory.sh/chat
-    about:
-      Hang out with other Ory community members to ask and answer questions.
+    about: Hang out with other Ory community members to ask and answer questions.


### PR DESCRIPTION
sync action is failing, 
first I thought its bc

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, webfactory/ssh-agent@v0.4.1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

but then

```
Error:  Invalid configuration file `CODE_OF_CONDUCT.md`: Cannot find module 'ory-prettier-styles'
Error:  Require stack:
Error:  - /home/runner/.npm/_npx/b388654678d519d9/node_modules/prettier/index.js
Error:  - /home/runner/.npm/_npx/b388654678d519d9/node_modules/prettier/cli.js
Error:  - /home/runner/.npm/_npx/b388654678d519d9/node_modules/prettier/bin-prettier.js
Error: Process completed with exit code 2.
```

afaik ory-prettier-styles is not needed anywhere anymore.