### PR TITLE
fix: sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "devDependencies": {
         "license-checker": "^25.0.1",
-        "prettier": "2.7.1",
+        "ory-prettier-styles": "1.3.0",
+        "prettier": "^2.7.1",
         "prettier-plugin-packagejson": "^2.2.18",
         "text-runner": "5.0.2"
       }
@@ -1213,6 +1214,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/ory-prettier-styles": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ory-prettier-styles/-/ory-prettier-styles-1.3.0.tgz",
+      "integrity": "sha512-Vfn0G6CyLaadwcCamwe1SQCf37ZQfBDgMrhRI70dE/2fbE3Q43/xu7K5c32I5FGt/EliroWty5yBjmdkj0eWug==",
+      "dev": true
     },
     "node_modules/os-homedir": {
       "version": "1.0.2",
@@ -2839,6 +2846,12 @@
       "requires": {
         "mimic-fn": "^2.1.0"
       }
+    },
+    "ory-prettier-styles": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ory-prettier-styles/-/ory-prettier-styles-1.3.0.tgz",
+      "integrity": "sha512-Vfn0G6CyLaadwcCamwe1SQCf37ZQfBDgMrhRI70dE/2fbE3Q43/xu7K5c32I5FGt/EliroWty5yBjmdkj0eWug==",
+      "dev": true
     },
     "os-homedir": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
   "scripts": {
     "text-run": "text-run"
   },
+  "prettier": "ory-prettier-styles",
   "devDependencies": {
     "license-checker": "^25.0.1",
-    "prettier": "2.7.1",
+    "ory-prettier-styles": "1.3.0",
+    "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.18",
     "text-runner": "5.0.2"
   }

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -37,7 +37,7 @@ function replicate_all {
 	replicate ory/closed-reference-notifier action "Closed Reference Notifier" "$workspace" "$persist"
 	replicate ory/label-sync-action action "Label Sync Action" "$workspace" "$persist"
 	replicate ory/milestone-action action "Milestone Action" "$workspace" "$persist"
-	replicate ory/prettier-styles action "Prettier Styles" "$workspace" "$persist"
+#	replicate ory/prettier-styles action "Prettier Styles" "$workspace" "$persist"
 	replicate ory/build-buf-action action "Buildbuf Action" "$workspace" "$persist"
 	replicate ory/examples library "Examples" "$workspace" "$persist"
 	replicate ory/hydra-maester library "Ory Hydra Maester" "$workspace" "$persist"
@@ -128,9 +128,9 @@ function replicate {
 	fi
 	add_adopters_to_readme "$repo_path"
 	add_ecosystem_to_readme "$repo_path"
-	if test -f package.json; then
-		format "$repo_path"
-	fi
+#	if test -f package.json; then
+#		format "$repo_path"
+#	fi
 
 	# optionally commit
 	if [ "$persist" == "commit" ] || [ "$persist" == "push" ]; then
@@ -237,14 +237,14 @@ function create_workspace {
 	mktemp -d
 }
 
-function format {
-	header "FORMATTING"
-	local -r repo_path=$1
-	(
-		cd "$repo_path"
-		npx prettier --write "*.md" .github
-	)
-}
+# function format {
+# 	header "FORMATTING"
+# 	local -r repo_path=$1
+# 	(
+# 		cd "$repo_path"
+# 		npx prettier --write "*.md" .github
+# 	)
+# }
 
 function install_dependencies_on_ci {
 	header "INSTALLING DEPENDENCIES"

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -37,7 +37,7 @@ function replicate_all {
 	replicate ory/closed-reference-notifier action "Closed Reference Notifier" "$workspace" "$persist"
 	replicate ory/label-sync-action action "Label Sync Action" "$workspace" "$persist"
 	replicate ory/milestone-action action "Milestone Action" "$workspace" "$persist"
-	#	replicate ory/prettier-styles action "Prettier Styles" "$workspace" "$persist"
+	replicate ory/prettier-styles action "Prettier Styles" "$workspace" "$persist"
 	replicate ory/build-buf-action action "Buildbuf Action" "$workspace" "$persist"
 	replicate ory/examples library "Examples" "$workspace" "$persist"
 	replicate ory/hydra-maester library "Ory Hydra Maester" "$workspace" "$persist"
@@ -128,9 +128,9 @@ function replicate {
 	fi
 	add_adopters_to_readme "$repo_path"
 	add_ecosystem_to_readme "$repo_path"
-	#	if test -f package.json; then
-	#		format "$repo_path"
-	#	fi
+	if test -f package.json; then
+		format "$repo_path"
+	fi
 
 	# optionally commit
 	if [ "$persist" == "commit" ] || [ "$persist" == "push" ]; then
@@ -237,14 +237,14 @@ function create_workspace {
 	mktemp -d
 }
 
-# function format {
-# 	header "FORMATTING"
-# 	local -r repo_path=$1
-# 	(
-# 		cd "$repo_path"
-# 		npx prettier --write "*.md" .github
-# 	)
-# }
+function format {
+	header "FORMATTING"
+	local -r repo_path=$1
+	(
+		cd "$repo_path"
+		npx prettier --write "*.md" .github
+	)
+}
 
 function install_dependencies_on_ci {
 	header "INSTALLING DEPENDENCIES"

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -37,7 +37,7 @@ function replicate_all {
 	replicate ory/closed-reference-notifier action "Closed Reference Notifier" "$workspace" "$persist"
 	replicate ory/label-sync-action action "Label Sync Action" "$workspace" "$persist"
 	replicate ory/milestone-action action "Milestone Action" "$workspace" "$persist"
-#	replicate ory/prettier-styles action "Prettier Styles" "$workspace" "$persist"
+	#	replicate ory/prettier-styles action "Prettier Styles" "$workspace" "$persist"
 	replicate ory/build-buf-action action "Buildbuf Action" "$workspace" "$persist"
 	replicate ory/examples library "Examples" "$workspace" "$persist"
 	replicate ory/hydra-maester library "Ory Hydra Maester" "$workspace" "$persist"
@@ -128,9 +128,9 @@ function replicate {
 	fi
 	add_adopters_to_readme "$repo_path"
 	add_ecosystem_to_readme "$repo_path"
-#	if test -f package.json; then
-#		format "$repo_path"
-#	fi
+	#	if test -f package.json; then
+	#		format "$repo_path"
+	#	fi
 
 	# optionally commit
 	if [ "$persist" == "commit" ] || [ "$persist" == "push" ]; then


### PR DESCRIPTION
fix: disable format in sync

This fixes the sync action by commenting out the format steps in the script. All the files are formatted anyway so I dont see why we would need it here and it breaks this sync action for a long time now due to missing ory-prettier-styles. 
This is not the ideal solution, but I gave up trying to fix it in another way after some time...