### PR TITLE
fix: use docker driver for Buildx in cve-scan workflow

### DIFF
--- a/templates/repository/server/.github/workflows/cve-scan.yaml
+++ b/templates/repository/server/.github/workflows/cve-scan.yaml
@@ -43,6 +43,8 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
       - name: Build images
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

- The default  driver used by  stores built images inside the Buildx builder container rather than the local
  Docker daemon. This causes downstream scanners (notably Kubescape) to fail because they cannot resolve the image.
- Setting  keeps the built image in the local daemon where all scanners can access it.

Example failure from : https://github.com/ory/oathkeeper/actions/runs/22443585810/job/64992030672?pr=1259


