### PR TITLE
security: avoid running from latest trivy-action tag

### DIFF
--- a/templates/repository/server/.github/workflows/cve-scan.yaml
+++ b/templates/repository/server/.github/workflows/cve-scan.yaml
@@ -91,7 +91,7 @@ jobs:
           # can't whitelist CVE yet: https://github.com/kubescape/kubescape/pull/1568
           severityThreshold: critical
       - name: Trivy Scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.35.0
         if: ${{ always() }}
         with:
           image-ref: ${{ env.IMAGE_NAME }}


### PR DESCRIPTION
According to
https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23, there was a time window during which master may have pointed to a malicious version of the action. To resolve this issue, pin to the known-safe version.

CVE-2026-33634