### PR TITLE
security: pin kubescape/github-action to a full commit SHA

### DIFF
--- a/templates/repository/server/.github/workflows/cve-scan.yaml
+++ b/templates/repository/server/.github/workflows/cve-scan.yaml
@@ -82,7 +82,7 @@ jobs:
         with:
           sarif_file: ${{ steps.grype-scan.outputs.sarif }}
       - name: Kubescape scanner
-        uses: kubescape/github-action@main
+        uses: kubescape/github-action@7d90c1f159f02df1e3c79f839eeabe42ea30d4e3 # pins @main as of 2026-06-01
         id: kubescape
         with:
           image: ${{ env.IMAGE_NAME }}


### PR DESCRIPTION
## What

Pin `kubescape/github-action` in the `cve-scan.yaml` server template to a full commit SHA instead of the mutable `@main` branch.

```diff
-        uses: kubescape/github-action@main
+        uses: kubescape/github-action@7d90c1f159f02df1e3c79f839eeabe42ea30d4e3 # pins @main as of 2026-06-01
```

## Why

In the `Docker Image Scanners` job, the runner logs in to `ghcr.io` with `${{ secrets.GITHUB_TOKEN }}` before the scanners run. Every subsequent step — including `kubescape/github-action` — therefore executes with a credentialed Docker session on the runner. Because that action is referenced by the moving `@main` branch, the exact code that runs in that credentialed context can change at any time without any change in this repository.

This is the same class of risk, in the same workflow, that #247 addressed for `trivy-action` after `master` briefly pointed to a malicious version (CVE-2026-33634). `kubescape/github-action@main` is the one third-party action here still on a branch ref, so this applies the same known-good hardening to it.

## Behaviour

`7d90c1f159f02df1e3c79f839eeabe42ea30d4e3` is the commit `@main` resolves to today (2026-06-01), so this pins to exactly what already runs — nothing about current behaviour changes, the ref is just fixed in place.

I deliberately did **not** pin to the latest release tag: `v3.0.21` is from 2024-11 and `main` is ~18 months ahead of it, so pinning to the tag would silently roll those changes back. Pinning to current `@main` HEAD keeps behaviour identical. If you'd rather track a release, `v3.0.21` = `c9749b84d138c0cbbb702b258774954f5463b82e` — happy to switch to whichever you prefer.

Because this is the template, regenerating propagates the pin to the downstream server repos (kratos, hydra, keto, …).

## Notes

I used AI assistance to review the workflow and draft this change; I read and verified every line myself and take responsibility for it. I understand this needs the Ory CLA and will sign it. Thank you for maintaining Ory — glad to adjust or close if you'd prefer a different approach.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability and consistency of automated security vulnerability scanning by pinning the scanning tool to a specific version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->