### PR TITLE
security: harden shared workflows

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -9,21 +9,35 @@ on:
       - master
 
 jobs:
-  licenses:
+  check:
     name: License compliance
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Install script
-        uses: ory/ci/licenses/setup@master
+        uses: ory/ci/licenses/setup@99c3afad6f2bcb8e8f557fd1abe9d0044e884b69 # fixed revision
         with:
-          token: ${{ secrets.ORY_BOT_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
       - name: Check licenses
-        uses: ory/ci/licenses/check@master
+        uses: ory/ci/licenses/check@99c3afad6f2bcb8e8f557fd1abe9d0044e884b69 # fixed revision
+
+  write:
+    name: Update license overview
+    if:
+      ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v3') }}
+    needs: check
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install script
+        uses: ory/ci/licenses/setup@99c3afad6f2bcb8e8f557fd1abe9d0044e884b69 # fixed revision
+        with:
+          token: ${{ secrets.ORY_BOT_PAT || github.token }}
       - name: Write, commit, push licenses
-        uses: ory/ci/licenses/write@master
-        if:
-          ${{ github.ref == 'refs/heads/main' || github.ref ==
-          'refs/heads/master' || github.ref == 'refs/heads/v3' }}
+        uses: ory/ci/licenses/write@99c3afad6f2bcb8e8f557fd1abe9d0044e884b69 # fixed revision
         with:
           author-email:
             ${{ secrets.ORY_BOT_PAT &&

--- a/templates/repository/common/.github/workflows/closed_references.yml
+++ b/templates/repository/common/.github/workflows/closed_references.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Find closed references
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
+      - uses: actions/setup-node@27082cecf3ff7a1742dbd5e12605f0cb59dce2d9 # v2-beta
         with:
           node-version: "14"
-      - uses: ory/closed-reference-notifier@v1
+      - uses: ory/closed-reference-notifier@e389079345c8c974f59bd8ee2869539b41de8252 # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issueLabels: upstream,good first issue,help wanted

--- a/templates/repository/common/.github/workflows/conventional_commits.yml
+++ b/templates/repository/common/.github/workflows/conventional_commits.yml
@@ -21,9 +21,9 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
       - id: config
-        uses: ory/ci/conventional_commit_config@master
+        uses: ory/ci/conventional_commit_config@99c3afad6f2bcb8e8f557fd1abe9d0044e884b69 # fixed revision
         with:
           config_path: .github/conventional_commits.json
           default_types: |
@@ -43,7 +43,7 @@ jobs:
             deps
             docs
           default_require_scope: false
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@505e44b4f33b4c801f063838b3f053990ee46ea7 # v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/templates/repository/common/.github/workflows/labels.yml
+++ b/templates/repository/common/.github/workflows/labels.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
       - name: Synchronize Issue Labels
-        uses: ory/label-sync-action@v0
+        uses: ory/label-sync-action@f080c2b8ac988f2fc90ddbbc8749c6ee55477f21 # v0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           dry: false

--- a/templates/repository/common/.github/workflows/licenses.yml
+++ b/templates/repository/common/.github/workflows/licenses.yml
@@ -9,21 +9,35 @@ on:
       - master
 
 jobs:
-  licenses:
+  check:
     name: License compliance
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Install script
-        uses: ory/ci/licenses/setup@master
+        uses: ory/ci/licenses/setup@99c3afad6f2bcb8e8f557fd1abe9d0044e884b69 # fixed revision
         with:
-          token: ${{ secrets.ORY_BOT_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
       - name: Check licenses
-        uses: ory/ci/licenses/check@master
+        uses: ory/ci/licenses/check@99c3afad6f2bcb8e8f557fd1abe9d0044e884b69 # fixed revision
+
+  write:
+    name: Update license overview
+    if:
+      ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v3') }}
+    needs: check
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install script
+        uses: ory/ci/licenses/setup@99c3afad6f2bcb8e8f557fd1abe9d0044e884b69 # fixed revision
+        with:
+          token: ${{ secrets.ORY_BOT_PAT || github.token }}
       - name: Write, commit, push licenses
-        uses: ory/ci/licenses/write@master
-        if:
-          ${{ github.ref == 'refs/heads/main' || github.ref ==
-          'refs/heads/master' || github.ref == 'refs/heads/v3' }}
+        uses: ory/ci/licenses/write@99c3afad6f2bcb8e8f557fd1abe9d0044e884b69 # fixed revision
         with:
           author-email:
             ${{ secrets.ORY_BOT_PAT &&

--- a/templates/repository/common/.github/workflows/stale.yml
+++ b/templates/repository/common/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.repository_owner == 'ory'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da # v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: |


### PR DESCRIPTION
## Summary

- pin action dependencies in the five shared workflow templates to immutable commit SHAs
- pin the license workflows to the fixed `ory/ci` revision
- separate read-only license checks from protected-branch license updates

## Motivation

The shared templates used mutable action references, and license validation shared a job with write-capable behavior. This change gives pull request checks read-only permissions while preserving license updates on pushes to `main`, `master`, and `v3`.

## Validation

- `make test`
- `actionlint` on the five shared templates and live license workflow
- Prettier check
- full-SHA reference and template parity checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security & Reliability**
  - Pinned workflow actions to fixed revisions for more predictable and secure automation.
  - Added read-only permissions for license checks and restricted write operations to approved branch pushes.
  - Improved license update handling with safer token selection and validation before changes are written.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->