### PR TITLE
chore: bump action versions in common workflow templates

### DIFF
--- a/templates/repository/common/.github/workflows/closed_references.yml
+++ b/templates/repository/common/.github/workflows/closed_references.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Find closed references
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v2-beta
         with:
           node-version: "14"

--- a/templates/repository/common/.github/workflows/conventional_commits.yml
+++ b/templates/repository/common/.github/workflows/conventional_commits.yml
@@ -21,7 +21,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - id: config
         uses: ory/ci/conventional_commit_config@master
         with:
@@ -43,7 +43,7 @@ jobs:
             deps
             docs
           default_require_scope: false
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/templates/repository/common/.github/workflows/labels.yml
+++ b/templates/repository/common/.github/workflows/labels.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Synchronize Issue Labels
         uses: ory/label-sync-action@v0
         with:

--- a/templates/repository/common/.github/workflows/stale.yml
+++ b/templates/repository/common/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.repository_owner == 'ory'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v11
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: |


### PR DESCRIPTION
The common workflow templates pin `actions/checkout@v2`/`@v3` and `actions/stale@v4`, which run on Node runtimes GitHub Actions no longer supports. actionlint (1.7.x) rejects them:

```
the runner of "actions/checkout@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue
```

Downstream repositories had already been bumped by renovate, but the template sync overwrote those bumps with the older pins from here. In ory/k8s the Aug 28 sync (ory/k8s@6428f395) downgraded `checkout@v7` to `v2`/`v3`, `action-semantic-pull-request@v6` to `v4` and `stale@v11` to `v4`, which turned the `Validation - GHA Linter` workflow and the `Lint GithubAction files` CI job red on every PR touching `.github/**`. See ory/k8s#897, which restores the versions locally; this PR fixes the source so the next sync does not reintroduce the downgrade.

Changes, all in `templates/repository/common/.github/workflows/`:

| File | Before | After |
|---|---|---|
| `closed_references.yml` | `actions/checkout@v2` | `actions/checkout@v7` |
| `conventional_commits.yml` | `actions/checkout@v3` | `actions/checkout@v7` |
| `conventional_commits.yml` | `amannn/action-semantic-pull-request@v4` | `amannn/action-semantic-pull-request@v6` |
| `labels.yml` | `actions/checkout@v2` | `actions/checkout@v7` |
| `stale.yml` | `actions/stale@v4` | `actions/stale@v11` |

These are the exact versions that were in place in ory/k8s before the sync, so downstream behaviour is unchanged. actionlint 1.7.12 passes on the edited templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated repository automation workflows to use newer versions of their checkout, commit-validation, pull-request validation, and stale-item actions.
  * Existing workflow schedules, triggers, and configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->